### PR TITLE
"all at once" reimplementation (ScratchBlocks Part)

### DIFF
--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -193,13 +193,13 @@ class Scratch3ControlBlocks {
     }
 
     allAtOnce (args, util) {
-        // Since the "all at once" block is implemented for compatiblity with
-        // Scratch 2.0 projects, it behaves the same way it did in 2.0, which
-        // is to simply run the contained script (like "if 1 = 1").
-        // (In early versions of Scratch 2.0, it would work the same way as
-        // "run without screen refresh" custom blocks do now, but this was
-        // removed before the release of 2.0.)
+        // In Scratch 3.0 and TurboWarp, this would simply
+        // run the contained substack. In Unsandboxed, 
+        // we've reimplemented the intended functionality 
+        // of running the stack all in one frame.
+        util.thread.peekStackFrame().warpMode = false;
         util.startBranch(1, false);
+        util.thread.peekStackFrame().warpMode = true;
     }
 }
 

--- a/src/blocks/scratch3_control.js
+++ b/src/blocks/scratch3_control.js
@@ -194,8 +194,8 @@ class Scratch3ControlBlocks {
 
     allAtOnce (args, util) {
         // In Scratch 3.0 and TurboWarp, this would simply
-        // run the contained substack. In Unsandboxed, 
-        // we've reimplemented the intended functionality 
+        // run the contained substack. In Unsandboxed,
+        // we've reimplemented the intended functionality
         // of running the stack all in one frame.
         util.thread.peekStackFrame().warpMode = false;
         util.startBranch(1, false);

--- a/src/compiler/jsgen.js
+++ b/src/compiler/jsgen.js
@@ -876,6 +876,13 @@ class JSGenerator {
             this.source += `}\n`;
             break;
 
+        case 'control.allAtOnce':
+            const previousWarp = this.isWarp;
+            this.isWarp = true;
+            this.descendStack(node.code, new Frame(false, 'control.allAtOnce'));
+            this.isWarp = previousWarp;
+            break;
+
         case 'counter.clear':
             this.source += 'runtime.ext_scratch3_control._counter = 0;\n';
             break;


### PR DESCRIPTION
Reimplements the deprecated "all at once" block.
- Adds warp functionality for "control_all_at_once" to interpreter and compiler.