### PR TITLE
ArgumentType.LABEL

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -128,7 +128,7 @@ const ArgumentTypeMap = (() => {
         fieldName: 'VARIABLE'
     };
     map[ArgumentType.LABEL] = {
-        fieldType: 'field_label',
+        fieldType: 'field_label_serializable',
         fieldName: 'LABEL'
     };
     return map;

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -127,6 +127,10 @@ const ArgumentTypeMap = (() => {
         fieldType: 'field_variable',
         fieldName: 'VARIABLE'
     };
+    map[ArgumentType.LABEL] = {
+        fieldType: 'field_label',
+        fieldName: 'LABEL'
+    };
     return map;
 })();
 
@@ -1639,6 +1643,9 @@ class Runtime extends EventEmitter {
         // check if this is not one of those cases. E.g. an inline image on a block.
         if (argTypeInfo.fieldType === 'field_image') {
             argJSON = this._constructInlineImageJson(argInfo);
+        } else if (argTypeInfo.fieldType === 'field_label') {
+            argJSON.type = 'field_label';
+            argJSON.text = argInfo.text;
         } else if (argTypeInfo.fieldType === 'field_variable') {
             argJSON = this._constructVariableJson(argInfo, placeholder);
         } else {

--- a/src/extension-support/argument-type.js
+++ b/src/extension-support/argument-type.js
@@ -56,7 +56,12 @@ const ArgumentType = {
     /**
      * Name of variable in the current specified target(s)
      */
-    VARIABLE: 'variable'
+    VARIABLE: 'variable',
+
+    /**
+     * A label text that can be dynamically changed
+     */
+    LABEL: 'label'
 };
 
 module.exports = ArgumentType;


### PR DESCRIPTION
An argument identically similar to the text of a block that can be changed with the value of the argument. I imagine this being used in places similar to field_variablegetter, like Dictionaries.

Not sure about this one yet, though.