### PR TITLE
Wrap clamp the color effect value

### DIFF
--- a/src/blocks/scratch3_looks.js
+++ b/src/blocks/scratch3_looks.js
@@ -314,6 +314,9 @@ class Scratch3LooksBlocks {
 
     getMonitored () {
         return {
+            looks_effect: {
+                getId: (targetId, fields) => getMonitorIdForBlockWithArgs(`${targetId}_effect`, fields)
+            },
             looks_size: {
                 isSpriteSpecific: true,
                 getId: targetId => `${targetId}_size`

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -402,6 +402,12 @@ class RenderedTarget extends Target {
      */
     setEffect (effectName, value) { // used by compiler
         if (!Object.prototype.hasOwnProperty.call(this.effects, effectName)) return;
+
+        // "Infinity" is often used to get a monochrome effect.
+        if (effectName === 'color' && isFinite(value) {
+            value = MathUtil.wrapClamp(value, 0, 200);
+        }
+
         this.effects[effectName] = value;
         if (this.renderer) {
             this.renderer.updateDrawableEffect(this.drawableID, effectName, value);


### PR DESCRIPTION
In Scratch/TW, the color effect shader does some weird things even when it eventually wraps around to 200 (effectively 0).

![image](https://github.com/Unsandboxed/scratch-vm/assets/127533508/9437d9eb-5a31-471a-b63b-aa78627a6098)
