### PR TITLE
Incorporate new Object and Array types

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -97,6 +97,12 @@ const ArgumentTypeMap = (() => {
     map[ArgumentType.BOOLEAN] = {
         check: 'Boolean'
     };
+    map[ArgumentType.ARRAY] = {
+        check: 'Array'
+    };
+    map[ArgumentType.OBJECT] = {
+        check: 'Object'
+    };
     map[ArgumentType.MATRIX] = {
         shadow: {
             type: 'matrix',
@@ -1457,6 +1463,14 @@ class Runtime extends EventEmitter {
             blockInfo.branchCount = blockInfo.branchCount || 1;
             blockJSON.output = blockInfo.allowDropAnywhere ? null : 'String'; // TODO: distinguish number & string here?
             blockJSON.outputShape = ScratchBlocksConstants.OUTPUT_SHAPE_SQUARE;
+            break;
+        case BlockType.ARRAY:
+            blockJSON.output = 'Array';
+            blockJSON.outputShape = ScratchBlocksConstants.OUTPUT_SHAPE_SQUARE;
+            break;
+        case BlockType.OBJECT:
+            blockJSON.output = 'Object';
+            blockJSON.outputShape = ScratchBlocksConstants.OUTPUT_SHAPE_OBJECT;
             break;
         }
 

--- a/src/engine/scratch-blocks-constants.js
+++ b/src/engine/scratch-blocks-constants.js
@@ -12,16 +12,22 @@ const ScratchBlocksConstants = {
     OUTPUT_SHAPE_HEXAGONAL: 1,
 
     /**
-     * ENUM for output shape: rounded (numbers).
+     * ENUM for output shape: rounded (numbers and strings).
      * @const
      */
     OUTPUT_SHAPE_ROUND: 2,
 
     /**
-     * ENUM for output shape: squared (any/all values; strings).
+     * ENUM for output shape: squared (arrays).
      * @const
      */
-    OUTPUT_SHAPE_SQUARE: 3
+    OUTPUT_SHAPE_SQUARE: 3,
+
+    /**
+     * ENUM for output shape: object (objects).
+     * @const
+     */
+    OUTPUT_SHAPE_OBJECT: 4
 };
 
 module.exports = ScratchBlocksConstants;

--- a/src/extension-support/argument-type.js
+++ b/src/extension-support/argument-type.js
@@ -54,7 +54,7 @@ const ArgumentType = {
     NUMBER: 'number',
 
     /**
-     * Numeric value with text field
+     * A representation of a JSON object.
      */
     OBJECT: 'Object',
 

--- a/src/extension-support/argument-type.js
+++ b/src/extension-support/argument-type.js
@@ -9,6 +9,11 @@ const ArgumentType = {
     ANGLE: 'angle',
 
     /**
+     * A representation of a JSON array.
+     */
+    ARRAY: 'array',
+
+    /**
      * Boolean value with hexagonal placeholder
      */
     BOOLEAN: 'Boolean',
@@ -19,14 +24,19 @@ const ArgumentType = {
     COLOR: 'color',
 
     /**
-     * Numeric value with text field
+     * Name of costume in the current target
      */
-    NUMBER: 'number',
+    COSTUME: 'costume',
 
     /**
-     * String value with text field
+     * Inline image on block (as part of the label)
      */
-    STRING: 'string',
+    IMAGE: 'image',
+
+    /**
+     * A label text that can be dynamically changed
+     */
+    LABEL: 'label',
 
     /**
      * String value with matrix field
@@ -39,14 +49,19 @@ const ArgumentType = {
     NOTE: 'note',
 
     /**
-     * Inline image on block (as part of the label)
+     * Numeric value with text field
      */
-    IMAGE: 'image',
+    NUMBER: 'number',
 
     /**
-     * Name of costume in the current target
+     * Numeric value with text field
      */
-    COSTUME: 'costume',
+    OBJECT: 'Object',
+
+    /**
+     * A reporter that can be defined using startHats.
+     */
+    PARAMETER: 'parameter',
 
     /**
      * Name of sound in the current target
@@ -54,19 +69,14 @@ const ArgumentType = {
     SOUND: 'sound',
 
     /**
+     * String value with text field
+     */
+    STRING: 'string',
+
+    /**
      * Name of variable in the current specified target(s)
      */
     VARIABLE: 'variable',
-
-    /**
-     * A label text that can be dynamically changed
-     */
-    LABEL: 'label',
-
-    /**
-     * A reporter that can be defined using startHats.
-     */
-    PARAMETER: 'parameter'
 };
 
 module.exports = ArgumentType;

--- a/src/extension-support/block-type.js
+++ b/src/extension-support/block-type.js
@@ -4,6 +4,16 @@
  */
 const BlockType = {
     /**
+     * Array reporter with a square shape.
+     */
+    ARRAY: 'array',
+
+    /**
+     * Array reporter with a square shape.
+     */
+    OBJECT: 'Object',
+
+    /**
      * Boolean reporter with hexagonal shape
      */
     BOOLEAN: 'Boolean',
@@ -41,6 +51,12 @@ const BlockType = {
     HAT: 'hat',
 
     /**
+     * Specialized reporter block that allows for the insertion and evaluation
+     * of a substack.
+     */
+    INLINE: 'inline',
+
+    /**
      * Specialized command block which may or may not run a child branch
      * If a child branch runs, the thread evaluates the loop block again.
      */
@@ -55,12 +71,6 @@ const BlockType = {
      * Arbitrary scratch-blocks XML.
      */
     XML: 'xml',
-
-    /**
-     * Specialized reporter block that allows for the insertion and evaluation
-     * of a substack.
-     */
-    INLINE: 'inline'
 };
 
 module.exports = BlockType;

--- a/src/extension-support/block-type.js
+++ b/src/extension-support/block-type.js
@@ -9,7 +9,7 @@ const BlockType = {
     ARRAY: 'array',
 
     /**
-     * Array reporter with a square shape.
+     * Object reporter with a lemon shape.
      */
     OBJECT: 'Object',
 


### PR DESCRIPTION
Incorporates the new Block/ArgumentTypes "OBJECT" and "ARRAY".

Worth noting that these are not supported by the rest of Unsandboxed, and outputting arrays/objects is still very dangerous.