### PR TITLE
Support "Object" and "Array" in the compiler

### DIFF
--- a/src/compiler/irgen.js
+++ b/src/compiler/irgen.js
@@ -783,7 +783,7 @@ class ScriptTreeGenerator {
                 const blockInfo = this.getBlockInfo(block.opcode);
                 if (blockInfo) {
                     const type = blockInfo.info.blockType;
-                    if (type === BlockType.REPORTER || type === BlockType.BOOLEAN || type === BlockType.INLINE) {
+                    if (type === BlockType.ARRAY || type === BlockType.OBJECT || type === BlockType.REPORTER || type === BlockType.BOOLEAN || type === BlockType.INLINE) {
                         return this.descendCompatLayer(block);
                     }
                 }


### PR DESCRIPTION
Add the absolute bare minimum to at least not throw an error for the new block types. This will probably not stay as it is.