### PR TITLE
Fix saving new categories

### DIFF
--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -44,6 +44,7 @@ const INPUT_DIFF_BLOCK_SHADOW = 3; // obscured shadow
 // Constants used during deserialization of an SB3 file
 const CORE_EXTENSIONS = [
     'argument',
+    'camera',
     'colour',
     'control',
     'data',
@@ -54,6 +55,7 @@ const CORE_EXTENSIONS = [
     'operator',
     'procedures',
     'sensing',
+    'string',
     'sound'
 ];
 


### PR DESCRIPTION
Fix some issues with Unsandboxed thinking that the camera/string categories are actually extensions.