### PR TITLE
Camera Zoom and Rotation (VM part)

### DIFF
--- a/src/blocks/scratch3_camera.js
+++ b/src/blocks/scratch3_camera.js
@@ -16,6 +16,12 @@ class Scratch3CameraBlocks {
             },
             camera_yposition: {
                 getId: () => 'yposition'
+            },
+            camera_zoom: {
+                getId: () => 'zoom'
+            },
+            camera_rotation: {
+                getId: () => 'rotation'
             }
         };
     }
@@ -32,8 +38,15 @@ class Scratch3CameraBlocks {
             camera_changex: this.changeX,
             camera_sety: this.setY,
             camera_changey: this.changeY,
+            camera_setzoom: this.setZoom,
+            camera_changezoom: this.changeZoom,
+            camera_turnright: this.turnRight,
+            camera_turnleft: this.turnLeft,
+            camera_pointindirection: this.pointInDirection,
             camera_xposition: this.getCameraX,
-            camera_yposition: this.getCameraY
+            camera_yposition: this.getCameraY,
+            camera_zoom: this.getCameraZoom,
+            camera_rotation: this.getCameraRotation
         };
     }
 
@@ -73,12 +86,48 @@ class Scratch3CameraBlocks {
         this.runtime.camera.setXY(this.runtime.camera.x, newY);
     }
 
+    setZoom (args) {
+        const zoom = Cast.toNumber(args.ZOOM);
+        this.runtime.camera.setZoom(zoom);
+    }
+
+    changeZoom (args) {
+        const zoom = Cast.toNumber(args.ZOOM);
+        const newZoom = zoom + this.runtime.camera.zoom;
+        this.runtime.camera.setZoom(newZoom);
+    }
+
+    turnRight (args) {
+        const degrees = Cast.toNumber(args.DEGREES);
+        const newRotation = this.runtime.camera.direction + degrees;
+        this.runtime.camera.setDirection(newRotation);
+    }
+
+    turnLeft (args) {
+        const degrees = Cast.toNumber(args.DEGREES);
+        const newRotation = this.runtime.camera.direction - degrees;
+        this.runtime.camera.setDirection(newRotation);
+    }
+
+    pointInDirection (args) {
+        const direction = Cast.toNumber(args.DIRECTION);
+        this.runtime.camera.setDirection(direction);
+    }
+
     getCameraX () {
         return this.runtime.camera.x;
     }
 
     getCameraY () {
         return this.runtime.camera.y;
+    }
+
+    getCameraZoom () {
+        return this.runtime.camera.zoom;
+    }
+
+    getCameraRotation () {
+        return this.runtime.camera.direction;
     }
 }
 

--- a/src/blocks/scratch3_motion.js
+++ b/src/blocks/scratch3_motion.js
@@ -127,6 +127,12 @@ class Scratch3MotionBlocks {
         const targetXY = this.getTargetXY(args.TO, util);
         if (targetXY) {
             util.target.setXY(targetXY[0], targetXY[1]);
+            if (args.TO === '_camera_') {
+                // Mark this sprite as sticky-camera so the runtime re-snaps it
+                // to the camera's final position at the end of the frame.
+                util.target.followingCamera = true;
+                util.target.runtime._hasFollowingCameraTargets = true;
+            }
         }
     }
 

--- a/src/compiler/setup-compiler/camera.js
+++ b/src/compiler/setup-compiler/camera.js
@@ -12,7 +12,12 @@ module.exports = function (compilerData, {
         'camera_movetoxy',
         'camera_changex',
         'camera_changey',
-        'camera_changebyxy'
+        'camera_changebyxy',
+        'camera_setzoom',
+        'camera_changezoom',
+        'camera_turnright',
+        'camera_turnleft',
+        'camera_pointindirection'
     ], function (stg, block) {
         const args = {};
         switch (this.ir_opcode) {
@@ -21,6 +26,12 @@ module.exports = function (compilerData, {
         case 'camera.movetoxy':
             if ('X' in block.inputs) args.x = stg.descendInputOfBlock(block, 'X').toType(InputType.NUMBER);
             if ('Y' in block.inputs) args.y = stg.descendInputOfBlock(block, 'Y').toType(InputType.NUMBER);
+            break;
+        case 'camera.setzoom':
+            if ('ZOOM' in block.inputs) args.zoom = stg.descendInputOfBlock(block, 'ZOOM').toType(InputType.NUMBER);
+            break;
+        case 'camera.pointindirection':
+            if ('DIRECTION' in block.inputs) args.rotation = stg.descendInputOfBlock(block, 'DIRECTION').toType(InputType.NUMBER);
             break;
         case 'camera.changex':
         case 'camera.changey':
@@ -42,25 +53,87 @@ module.exports = function (compilerData, {
             } else args.y = new IntermediateInput('camera.yposition', InputType.NUMBER);
             break;
         }
+        case 'camera.changezoom':
+            args.disableModulo = true;
+            if ('ZOOM' in block.inputs) {
+                args.zoom = new IntermediateInput('operator.add', InputType.NUMBER, {
+                    left: new IntermediateInput('camera.zoom', InputType.NUMBER),
+                    right: stg.descendInputOfBlock(block, 'ZOOM').toType(InputType.NUMBER)
+                });
+            } else {
+                args.zoom = new IntermediateInput('camera.zoom', InputType.NUMBER);
+            }
+            break;
+        case 'camera.turnright':
+            args.disableModulo = true;
+            if ('DEGREES' in block.inputs) {
+                args.rotation = new IntermediateInput('operator.add', InputType.NUMBER, {
+                    left: new IntermediateInput('camera.rotation', InputType.NUMBER),
+                    right: stg.descendInputOfBlock(block, 'DEGREES').toType(InputType.NUMBER)
+                });
+            } else {
+                args.rotation = new IntermediateInput('camera.rotation', InputType.NUMBER);
+            }
+            break;
+        case 'camera.turnleft':
+            args.disableModulo = true;
+            if ('DEGREES' in block.inputs) {
+                args.rotation = new IntermediateInput('operator.subtract', InputType.NUMBER, {
+                    left: new IntermediateInput('camera.rotation', InputType.NUMBER),
+                    right: stg.descendInputOfBlock(block, 'DEGREES').toType(InputType.NUMBER)
+                });
+            } else {
+                args.rotation = new IntermediateInput('camera.rotation', InputType.NUMBER);
+            }
+            break;
         }
-        return new IntermediateStackBlock('camera.movetoxy', args);
+        switch (this.ir_opcode) {
+        case 'camera.setzoom':
+        case 'camera.changezoom':
+            return new IntermediateStackBlock('camera.setzoom', args);
+        case 'camera.pointindirection':
+        case 'camera.turnright':
+        case 'camera.turnleft':
+            return new IntermediateStackBlock('camera.setrotation', args);
+        default:
+            return new IntermediateStackBlock('camera.movetoxy', args);
+        }
     }, function (jsg, block) {
         jsg.descendedIntoModulo = false;
-        const x = 'x' in block.inputs ? jsg.descendInput(block.inputs.x) : 'runtime.camera.x';
-        const y = 'y' in block.inputs ? jsg.descendInput(block.inputs.y) : 'runtime.camera.y';
-        jsg.source += `runtime.camera.setXY(${x}, ${y});\n`;
+        switch (block.kind) {
+        case 'camera.setzoom': {
+            const zoom = 'zoom' in block.inputs ? jsg.descendInput(block.inputs.zoom) : 'runtime.camera.zoom';
+            jsg.source += `runtime.camera.setZoom(${zoom});\n`;
+            break;
+        }
+        case 'camera.setrotation': {
+            const rotation = 'rotation' in block.inputs ? jsg.descendInput(block.inputs.rotation) : 'runtime.camera.direction';
+            jsg.source += `runtime.camera.setDirection(${rotation});\n`;
+            break;
+        }
+        default: {
+            const x = 'x' in block.inputs ? jsg.descendInput(block.inputs.x) : 'runtime.camera.x';
+            const y = 'y' in block.inputs ? jsg.descendInput(block.inputs.y) : 'runtime.camera.y';
+            jsg.source += `runtime.camera.setXY(${x}, ${y});\n`;
+            break;
+        }
+        }
     }, {
         input: false
     });
     // Inputs
     compilerData.registerBlock([
         'camera_xposition',
-        'camera_yposition'
+        'camera_yposition',
+        'camera_zoom',
+        'camera_rotation'
     ], function () {
         return new IntermediateInput(this.ir_opcode, this.type);
     }, [
         `runtime.camera.x`,
-        `runtime.camera.y`
+        `runtime.camera.y`,
+        `runtime.camera.zoom`,
+        `runtime.camera.direction`
     ], {
         input: true,
         type: InputType.NUMBER

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -37,6 +37,12 @@ const Storage = require('../io/storage');
 const StringUtil = require('../util/string-util');
 const uid = require('../util/uid');
 
+const now = () => (
+    typeof performance !== 'undefined' && typeof performance.now === 'function' ?
+        performance.now() :
+        Date.now()
+);
+
 const defaultBlockPackages = {
     scratch3_control: require('../blocks/scratch3_control'),
     scratch3_event: require('../blocks/scratch3_event'),
@@ -551,7 +557,8 @@ class Runtime extends RuntimeConstants {
         this.runtimeOptions = {
             maxClones: RuntimeConstants.MAX_CLONES,
             miscLimits: false,
-            fencing: false
+            fencing: false,
+            stickyCamera: true
         };
 
         this.compilerOptions = {
@@ -567,9 +574,16 @@ class Runtime extends RuntimeConstants {
         }
         this.debug = false;
 
-        this._lastStepTime = Date.now();
+        this._lastStepTime = now();
         this.interpolationEnabled = false;
         this.interpolate = interpolate;
+
+        /**
+         * True if at least one target requested camera-follow this frame.
+         * Used to skip follower maintenance work when inactive.
+         * @type {boolean}
+         */
+        this._hasFollowingCameraTargets = false;
 
         this._defaultStoredSettings = this._generateAllProjectOptions();
 
@@ -2610,8 +2624,8 @@ class Runtime extends RuntimeConstants {
 
     _renderInterpolatedPositions () {
         const frameStarted = this._lastStepTime;
-        const now = Date.now();
-        const timeSinceStart = now - frameStarted;
+        const frameNow = now();
+        const timeSinceStart = frameNow - frameStarted;
         const progressInFrame = Math.min(1, Math.max(0, timeSinceStart / this.currentStepTime));
 
         interpolate.interpolate(this, progressInFrame);
@@ -2635,6 +2649,17 @@ class Runtime extends RuntimeConstants {
      * inactive threads after each iteration.
      */
     _step () {
+        // followingCamera is a per-frame marker set by "go to [camera]".
+        // Only clear it if at least one target used it in the previous frame.
+        if (this._hasFollowingCameraTargets) {
+            for (const target of this.targets) {
+                if (target.followingCamera) {
+                    target.followingCamera = false;
+                }
+            }
+            this._hasFollowingCameraTargets = false;
+        }
+
         if (this._refreshGlobalProceduresMutations) {
             this._refreshGlobalProceduresMutations = false;
             this._updateGlobalProceduresMutations();
@@ -2686,6 +2711,44 @@ class Runtime extends RuntimeConstants {
             this.profiler.stop();
         }
         this.emit(RuntimeConstants.AFTER_EXECUTE);
+
+        // Keep model state in sync with camera-follow rendering so the normal
+        // per-step draw (non-interpolated) and interpolation draws don't fight.
+        if (this.runtimeOptions.stickyCamera && this._hasFollowingCameraTargets) {
+            const camX = this.camera.x;
+            const camY = this.camera.y;
+            for (const target of this.targets) {
+                if (target.followingCamera) {
+                    // Keep camera-following exact: bypass setXY so fencing/clamping
+                    // doesn't introduce sub-frame wobble against camera interpolation.
+                    const oldX = target.x;
+                    const oldY = target.y;
+                    target.x = camX;
+                    target.y = camY;
+
+                    if (target.renderer && typeof target.drawableID === 'number') {
+                        if (typeof target.renderer.updateDrawablePositionExact === 'function') {
+                            target.renderer.updateDrawablePositionExact(target.drawableID, [camX, camY]);
+                        } else {
+                            target.renderer.updateDrawablePosition(target.drawableID, [camX, camY]);
+                        }
+                        if (target.visible) {
+                            target.emitVisualChange();
+                            this.requestRedraw();
+                        }
+                    }
+
+                    if (target.onTargetMoved) {
+                        target.onTargetMoved(target, oldX, oldY, true);
+                    }
+                    this.requestTargetsUpdate(target);
+
+                    // Preserve per-frame marker through interpolation passes.
+                    target.followingCamera = true;
+                }
+            }
+        }
+
         this._updateGlows(doneThreads);
         // Add done threads so that even if a thread finishes within 1 frame, the green
         // flag will still indicate that a script ran.
@@ -2730,7 +2793,7 @@ class Runtime extends RuntimeConstants {
         }
 
         if (this.interpolationEnabled || targetHasInterpolation) {
-            this._lastStepTime = Date.now();
+            this._lastStepTime = now();
         }
     }
 

--- a/src/engine/tw-interpolate.js
+++ b/src/engine/tw-interpolate.js
@@ -65,6 +65,8 @@ const setupInitialState = runtime => {
 const interpolate = (runtime, time) => {
     const renderer = runtime.renderer;
     const camera = runtime.camera;
+    let cameraRenderX = camera.x;
+    let cameraRenderY = camera.y;
 
     if (!renderer) {
         return;
@@ -83,9 +85,30 @@ const interpolate = (runtime, time) => {
             // Large movements are likely intended to be instantaneous.
             const distance = Math.sqrt((absoluteXDistance ** 2) + (absoluteYDistance ** 2));
             if (distance < 50) {
-                const newX = interpolationData.x + (xDistance * time);
-                const newY = interpolationData.y + (yDistance * time);
-                renderer._updateCamera(newX, newY, camera.direction, camera.zoom);
+                cameraRenderX = interpolationData.x + (xDistance * time);
+                cameraRenderY = interpolationData.y + (yDistance * time);
+            }
+        }
+
+        renderer._updateCamera(
+            cameraRenderX,
+            cameraRenderY,
+            camera.direction,
+            camera.zoom
+        );
+
+        // When interpolation is enabled, move camera-following targets immediately
+        // after camera interpolation so they use the camera's current interpolated
+        // position for this sub-frame.
+        if (runtime.interpolationEnabled && runtime.runtimeOptions.stickyCamera && runtime._hasFollowingCameraTargets) {
+            for (const target of runtime.targets) {
+                if (target.followingCamera && target.visible && !target.isStage) {
+                    if (typeof renderer.updateDrawablePositionExact === 'function') {
+                        renderer.updateDrawablePositionExact(target.drawableID, [cameraRenderX, cameraRenderY]);
+                    } else {
+                        renderer.updateDrawablePosition(target.drawableID, [cameraRenderX, cameraRenderY]);
+                    }
+                }
             }
         }
     }
@@ -107,6 +130,10 @@ const interpolate = (runtime, time) => {
                 interpolationData.ghost === 100
             )
         ) {
+            continue;
+        }
+
+        if (target.followingCamera) {
             continue;
         }
 

--- a/src/io/mouse.js
+++ b/src/io/mouse.js
@@ -63,31 +63,42 @@ class Mouse {
      * @param  {object} data Data from DOM event.
      */
     postData (data) {
-        if (typeof data.x === 'number') {
+        const hasX = typeof data.x === 'number';
+        const hasY = typeof data.y === 'number';
+        if (hasX) {
             this._clientX = data.x;
-            this._scratchX = MathUtil.clamp(
-                this.runtime.stageWidth * ((data.x / data.canvasWidth) - 0.5),
-                -(this.runtime.stageWidth / 2),
-                (this.runtime.stageWidth / 2)
-            );
-
-            // usb: transform based on camera
-            this._scratchX = this.runtime.renderer.translateX(
-                this._scratchX, false, 1, true, this._scratchY, 1
-            );
         }
-        if (typeof data.y === 'number') {
+        if (hasY) {
             this._clientY = data.y;
-            this._scratchY = MathUtil.clamp(
-                -this.runtime.stageHeight * ((data.y / data.canvasHeight) - 0.5),
-                -(this.runtime.stageHeight / 2),
-                (this.runtime.stageHeight / 2)
-            );
+        }
 
-            // usb: transform based on camera
-            this._scratchY = this.runtime.renderer.translateY(
-                this._scratchY, false, 1, true, this._scratchX, 1
-            );
+        if (hasX || hasY) {
+            const hasCanvasSize = typeof data.canvasWidth === 'number' && typeof data.canvasHeight === 'number';
+            // Clamp in screen/client space before camera inversion so stage bounds stay screen-aligned.
+            const constrainedClientX = hasCanvasSize ?
+                MathUtil.clamp(this._clientX, 0, data.canvasWidth) :
+                this._clientX;
+            const constrainedClientY = hasCanvasSize ?
+                MathUtil.clamp(this._clientY, 0, data.canvasHeight) :
+                this._clientY;
+
+            const renderer = this.runtime.renderer;
+            if (renderer) {
+                const [scratchX, scratchY] = renderer.clientSpaceToScratchPoint(constrainedClientX, constrainedClientY);
+                this._scratchX = scratchX;
+                this._scratchY = scratchY;
+            } else if (hasCanvasSize) {
+                this._scratchX = MathUtil.clamp(
+                    this.runtime.stageWidth * ((constrainedClientX / data.canvasWidth) - 0.5),
+                    -(this.runtime.stageWidth / 2),
+                    (this.runtime.stageWidth / 2)
+                );
+                this._scratchY = MathUtil.clamp(
+                    -this.runtime.stageHeight * ((constrainedClientY / data.canvasHeight) - 0.5),
+                    -(this.runtime.stageHeight / 2),
+                    (this.runtime.stageHeight / 2)
+                );
+            }
         }
         if (typeof data.isDown !== 'undefined') {
             // If no button specified, default to left button for compatibility
@@ -133,9 +144,7 @@ class Mouse {
      * @return {number} Non-clamped X position of the mouse cursor.
      */
     getClientX () {
-        return this.runtime.renderer.translateX(
-            this._clientX, true, 1, true, this._clientY, -1
-        );
+        return this._clientX;
     }
 
     /**
@@ -143,9 +152,7 @@ class Mouse {
      * @return {number} Non-clamped Y position of the mouse cursor.
      */
     getClientY () {
-        return this.runtime.renderer.translateY(
-            this._clientY, true, -1, true, this._clientX, 1
-        );
+        return this._clientY;
     }
 
     /**

--- a/src/sprites/rendered-target.js
+++ b/src/sprites/rendered-target.js
@@ -96,6 +96,14 @@ class RenderedTarget extends Target {
         this.draggable = false;
 
         /**
+         * True if the sprite's last positional movement this frame was "go to [camera]".
+         * When stickyCamera is enabled, the runtime re-snaps this sprite to the
+         * camera's final position at the end of that frame, then this flag is cleared.
+         * @type {boolean}
+         */
+        this.followingCamera = false;
+
+        /**
          * Whether the rendered target is currently visible.
          * @type {boolean}
          */
@@ -272,6 +280,8 @@ class RenderedTarget extends Target {
     setXY (x, y, force) { // used by compiler
         if (this.isStage) return;
         if (this.dragging && !force) return;
+        // Clear the sticky-camera flag — any "real" movement breaks camera-following.
+        this.followingCamera = false;
         const oldX = this.x;
         const oldY = this.y;
         if (this.renderer) {

--- a/src/util/resolvers.js
+++ b/src/util/resolvers.js
@@ -87,7 +87,7 @@ class Resolvers {
                 IS_MOUSE: true,
 
                 x: this.runtime.ioDevices.mouse.getScratchX(),
-                y: this.runtime.ioDevices.mouse.getScratchX(),
+                y: this.runtime.ioDevices.mouse.getScratchY(),
                 dir: 90,
                 czoom: this.runtime.camera.zoom
             };

--- a/test/unit/io_mouse_tw.js
+++ b/test/unit/io_mouse_tw.js
@@ -146,3 +146,30 @@ test('accepts 0 as x and y position', t => {
 
     t.end();
 });
+
+test('clamps client coordinates before renderer conversion', t => {
+    const rt = new Runtime();
+    const m = new Mouse(rt);
+
+    let convertedX = null;
+    let convertedY = null;
+    rt.renderer = {
+        clientSpaceToScratchPoint: (x, y) => {
+            convertedX = x;
+            convertedY = y;
+            // Keep this simple; this test only validates the clamped input to the renderer.
+            return [x, y];
+        }
+    };
+
+    m.postData({
+        x: 9999,
+        y: -9999,
+        canvasWidth: 480,
+        canvasHeight: 360
+    });
+
+    t.equal(convertedX, 480);
+    t.equal(convertedY, 0);
+    t.end();
+});


### PR DESCRIPTION
This improves interpolation a fair bit too, now sprites actually follow the camera's interpolated position instead of their own when necessary.

Also adds the pretty neat "sticky camera" runtime option so that sprites which are told to go the camera ACTUALLY DO IT. Should prevent a lot of the "jittery" problems people have with it at the very least.