### PR TITLE
Extension Interoperability

### DIFF
--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1105,7 +1105,10 @@ class Runtime extends RuntimeConstants {
      * @private
      */
     _buildMenuForScratchBlocks (menuName, menuInfo, categoryInfo) {
-        const menuId = this._makeExtensionMenuId(menuName, categoryInfo.id);
+        const menuExtensionId =
+            (menuInfo && typeof menuInfo.extensionId === 'string' && menuInfo.extensionId.length > 0) ?
+                menuInfo.extensionId : categoryInfo.id;
+        const menuId = this._makeExtensionMenuId(menuName, menuExtensionId);
         const menuItems = this._convertMenuItems(menuInfo.items);
         const acceptInput = (menuInfo.acceptText || menuInfo.acceptNumber);
         const type = menuInfo.acceptText ?
@@ -1515,13 +1518,16 @@ class Runtime extends RuntimeConstants {
 
                 const menuInfo = categoryInfo && categoryInfo.menuInfo ? categoryInfo.menuInfo[argInfo.menu] : null;
                 const convertedMenu = categoryInfo && categoryInfo.convertedMenuInfo ? categoryInfo.convertedMenuInfo[argInfo.menu] : null;
+                const menuExtensionId =
+                    (menuInfo && typeof menuInfo.extensionId === 'string' && menuInfo.extensionId.length > 0) ?
+                        menuInfo.extensionId : categoryInfo.id;
                 const acceptReporters = typeof argInfo.acceptReporters !== 'undefined' ?
                     argInfo.acceptReporters : (menuInfo && menuInfo.acceptReporters);
 
                 if (acceptReporters) {
                     // Menu semantics from argument definitions must override
                     // generic type defaults (e.g. STRING => text/TEXT shadow).
-                    resolved.shadow = this._makeExtensionMenuId(argInfo.menu, categoryInfo.id);
+                    resolved.shadow = this._makeExtensionMenuId(argInfo.menu, menuExtensionId);
                     resolved.field = argInfo.menu;
                     resolved.defaultValue = formatDefaultValue(argInfo);
                     return resolved;
@@ -1788,6 +1794,9 @@ class Runtime extends RuntimeConstants {
             let fieldName;
             if (argInfo.menu) {
                 const menuInfo = context.categoryInfo.menuInfo[argInfo.menu];
+                const menuExtensionId =
+                    (menuInfo && typeof menuInfo.extensionId === 'string' && menuInfo.extensionId.length > 0) ?
+                        menuInfo.extensionId : context.categoryInfo.id;
 
                 let acceptReporters = false;
                 if (typeof argInfo.acceptReporters !== 'undefined') {
@@ -1798,7 +1807,7 @@ class Runtime extends RuntimeConstants {
 
                 if (acceptReporters) {
                     valueName = placeholder;
-                    shadowType = this._makeExtensionMenuId(argInfo.menu, context.categoryInfo.id);
+                    shadowType = this._makeExtensionMenuId(argInfo.menu, menuExtensionId);
                     fieldName = argInfo.menu;
                 } else {
                     argJSON.type = 'field_dropdown';

--- a/src/engine/runtime.js
+++ b/src/engine/runtime.js
@@ -1220,7 +1220,10 @@ class Runtime extends RuntimeConstants {
      * @private
      */
     _convertBlockForScratchBlocks (blockInfo, categoryInfo) {
-        const extendedOpcode = `${categoryInfo.id}_${blockInfo.opcode}`;
+        const extendedOpcode =
+            (typeof blockInfo.extendedOpcode === 'string' && blockInfo.extendedOpcode.length > 0) ?
+                blockInfo.extendedOpcode :
+                `${categoryInfo.id}_${blockInfo.opcode}`;
 
         blockInfo = this._mapColours(blockInfo, false, categoryInfo);
 

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -491,9 +491,7 @@ class ExtensionManager {
                     providerBlock,
                     merged.menus,
                     provider.extensionInfo.menus || {},
-                    extensionInfo,
-                    provider.extensionInfo,
-                    providerIsLoaded
+                    provider.extensionInfo
                 );
 
                 this._requiredBlockOpcodeOwners.set(importedExtendedOpcode, extensionInfo.id);
@@ -638,22 +636,18 @@ class ExtensionManager {
         return null;
     }
 
-    _cloneRequiredBlockInfo (providerId, providerBlock, consumerMenus, providerMenus, consumerInfo, providerInfo,
-        providerIsLoaded) {
+    _cloneRequiredBlockInfo (providerId, providerBlock, consumerMenus, providerMenus, providerInfo) {
         const clonedBlock = Object.assign({}, providerBlock);
         clonedBlock.arguments = Object.assign({}, providerBlock.arguments || {});
         clonedBlock.extendedOpcode = `${providerId}_${providerBlock.opcode}`;
 
-        // Borrowed blocks use consumer colors until the provider is loaded.
-        const paletteSource = providerIsLoaded ? providerInfo : consumerInfo;
-        const color1 = paletteSource && paletteSource.color1;
-        const color2 = (paletteSource && paletteSource.color2) || color1;
-        const color3 = (paletteSource && paletteSource.color3) || color2;
-        const color4 = (paletteSource && paletteSource.color4) || color3;
-        clonedBlock.color1 = clonedBlock.color1 || color1;
-        clonedBlock.color2 = clonedBlock.color2 || color2;
-        clonedBlock.color3 = clonedBlock.color3 || color3;
-        clonedBlock.color4 = clonedBlock.color4 || color4;
+        const resolvedColors = this._resolveRequiredBlockColors(providerBlock, providerInfo);
+        if (resolvedColors) {
+            clonedBlock.color1 = resolvedColors.color1;
+            clonedBlock.color2 = resolvedColors.color2;
+            clonedBlock.color3 = resolvedColors.color3;
+            clonedBlock.color4 = resolvedColors.color4;
+        }
 
         for (const argumentName of Object.keys(clonedBlock.arguments)) {
             const argumentInfo = clonedBlock.arguments[argumentName];
@@ -664,12 +658,12 @@ class ExtensionManager {
             const clonedArgument = Object.assign({}, argumentInfo);
             if (typeof clonedArgument.menu === 'string') {
                 const sourceMenuName = clonedArgument.menu;
-                const importedMenuName = `required__${providerId}__${sourceMenuName}`;
-                clonedArgument.menu = importedMenuName;
-
-                if (!Object.prototype.hasOwnProperty.call(consumerMenus, importedMenuName) &&
+                if (!Object.prototype.hasOwnProperty.call(consumerMenus, sourceMenuName) &&
                     Object.prototype.hasOwnProperty.call(providerMenus, sourceMenuName)) {
-                    consumerMenus[importedMenuName] = providerMenus[sourceMenuName];
+                    const clonedMenuInfo = Object.assign({}, providerMenus[sourceMenuName], {
+                        extensionId: providerId
+                    });
+                    consumerMenus[sourceMenuName] = clonedMenuInfo;
                 }
             }
 
@@ -677,6 +671,23 @@ class ExtensionManager {
         }
 
         return clonedBlock;
+    }
+
+    _resolveRequiredBlockColors (providerBlock, providerInfo) {
+        if (!this.runtime || typeof this.runtime._mapColours !== 'function') {
+            return null;
+        }
+
+        const blockForColorMapping = Object.assign({}, providerBlock);
+        const providerFallbackColors = Object.assign({}, providerInfo || {});
+        const resolved = this.runtime._mapColours(blockForColorMapping, false, providerFallbackColors);
+
+        return {
+            color1: resolved.color1,
+            color2: resolved.color2,
+            color3: resolved.color3,
+            color4: resolved.color4
+        };
     }
 
     getRequiredBlockOwnerForOpcode (opcode) {

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -133,6 +133,20 @@ class ExtensionManager {
 
         this.builtinExtensions = Object.assign({}, ExtensionManager.defaultBuiltinExtensions);
 
+        /**
+         * Hidden provider extension services used only for required block imports.
+         * Map key is extension ID.
+         * @type {Map<string, {serviceName: string, extensionInfo: ExtensionInfo}>}
+         */
+        this._requiredBlockProviders = new Map();
+
+        /**
+         * Map imported required opcode => consumer extension ID.
+         * Used by serialization to persist consumer ownership without changing runtime opcode semantics.
+         * @type {Map<string, string>}
+         */
+        this._requiredBlockOpcodeOwners = new Map();
+
         dispatch.setService('extensions', ExtensionManager.createExtensionService(this)).catch(e => {
             log.error(`ExtensionManager was unable to register extension service: ${JSON.stringify(e)}`);
         });
@@ -191,6 +205,8 @@ class ExtensionManager {
         const extensionInstance = new extension(this.runtime);
         const serviceName = this._registerInternalExtension(extensionInstance);
         this._loadedExtensions.set(extensionId, serviceName);
+        this._requiredBlockProviders.delete(extensionId);
+        this._refreshRequiredBlockConsumers(extensionId);
         this.runtime.compilerRegisterExtension(extensionId, extensionInstance);
     }
 
@@ -301,6 +317,7 @@ class ExtensionManager {
         const refresh = serviceName => dispatch.call(serviceName, 'getInfo')
             .then(info => {
                 info = this._prepareExtensionInfo(serviceName, info);
+                info = this._injectRequiredBlocks(info);
                 dispatch.call('runtime', '_refreshExtensionPrimitives', info);
             })
             .catch(e => {
@@ -341,6 +358,8 @@ class ExtensionManager {
         dispatch.call(serviceName, 'getInfo').then(info => {
             this._loadedExtensions.set(info.id, serviceName);
             this._registerExtensionInfo(serviceName, info);
+            this._requiredBlockProviders.delete(info.id);
+            this._refreshRequiredBlockConsumers(info.id);
             this._finishedLoadingExtensionScript();
         });
     }
@@ -400,9 +419,265 @@ class ExtensionManager {
      */
     _registerExtensionInfo (serviceName, extensionInfo) {
         extensionInfo = this._prepareExtensionInfo(serviceName, extensionInfo);
+        extensionInfo = this._injectRequiredBlocks(extensionInfo);
         dispatch.call('runtime', '_registerExtensionPrimitives', extensionInfo).catch(e => {
             log.error(`Failed to register primitives for extension on service ${serviceName}:`, e);
         });
+    }
+
+    _injectRequiredBlocks (extensionInfo) {
+        if (!extensionInfo || !extensionInfo.requires || typeof extensionInfo.requires !== 'object') {
+            return extensionInfo;
+        }
+
+        for (const [opcode, ownerId] of this._requiredBlockOpcodeOwners.entries()) {
+            if (ownerId === extensionInfo.id) {
+                this._requiredBlockOpcodeOwners.delete(opcode);
+            }
+        }
+
+        const merged = Object.assign({}, extensionInfo, {
+            blocks: Array.isArray(extensionInfo.blocks) ? extensionInfo.blocks.slice() : [],
+            menus: Object.assign({}, extensionInfo.menus || {})
+        });
+
+        let insertedAny = false;
+
+        for (const providerId of Object.keys(extensionInfo.requires)) {
+            const providerIsLoaded = providerId !== extensionInfo.id && this._loadedExtensions.has(providerId);
+
+            const requestedBlocks = extensionInfo.requires[providerId];
+            if (!Array.isArray(requestedBlocks) || requestedBlocks.length === 0) {
+                continue;
+            }
+
+            const provider = this._getRequiredBlockProvider(providerId);
+            if (!provider) {
+                log.warn(`Unable to load required block provider: ${providerId}`);
+                continue;
+            }
+
+            const providerBlocks = provider.extensionInfo.blocks || [];
+
+            for (const requestedOpcode of requestedBlocks) {
+                const blockOpcode = String(requestedOpcode);
+                const importedExtendedOpcode = `${providerId}_${blockOpcode}`;
+
+                const alreadyImported = merged.blocks.some(block =>
+                    block &&
+                    typeof block === 'object' &&
+                    block.extendedOpcode === importedExtendedOpcode
+                );
+                if (alreadyImported) {
+                    continue;
+                }
+
+                const providerBlock = providerBlocks.find(block =>
+                    block &&
+                    block !== '---' &&
+                    block.opcode === blockOpcode
+                );
+
+                if (!providerBlock) {
+                    log.warn(`Required block ${importedExtendedOpcode} was not found in provider ${providerId}`);
+                    continue;
+                }
+
+                const importedBlock = this._cloneRequiredBlockInfo(
+                    providerId,
+                    providerBlock,
+                    merged.menus,
+                    provider.extensionInfo.menus || {},
+                    extensionInfo,
+                    provider.extensionInfo,
+                    providerIsLoaded
+                );
+
+                this._requiredBlockOpcodeOwners.set(importedExtendedOpcode, extensionInfo.id);
+
+                if (!insertedAny) {
+                    if (merged.blocks.length > 0 && merged.blocks[merged.blocks.length - 1] !== '---') {
+                        merged.blocks.push('---');
+                    }
+                    insertedAny = true;
+                }
+                merged.blocks.push(importedBlock);
+            }
+        }
+
+        return merged;
+    }
+
+    _refreshRequiredBlockConsumers (providerId) {
+        for (const [extensionId, serviceName] of this._loadedExtensions.entries()) {
+            if (extensionId === providerId) {
+                continue;
+            }
+
+            dispatch.call(serviceName, 'getInfo')
+                .then(info => {
+                    if (!info || !info.requires || typeof info.requires !== 'object') {
+                        return;
+                    }
+
+                    if (!Object.prototype.hasOwnProperty.call(info.requires, providerId)) {
+                        return;
+                    }
+
+                    return this.refreshBlocks(extensionId);
+                })
+                .catch(e => {
+                    log.warn(`Failed to refresh required block consumer ${extensionId} for provider ${providerId}: ${e.message}`);
+                });
+        }
+    }
+
+    _getRequiredBlockProvider (providerId) {
+        if (this._requiredBlockProviders.has(providerId)) {
+            return this._requiredBlockProviders.get(providerId);
+        }
+
+        // Reuse already loaded providers when available.
+        if (this._loadedExtensions.has(providerId)) {
+            const loadedService = this._loadedExtensions.get(providerId);
+            try {
+                const loadedInfo = this._prepareExtensionInfo(loadedService, dispatch.callSync(loadedService, 'getInfo'));
+                const loadedProvider = {
+                    serviceName: loadedService,
+                    extensionInfo: loadedInfo
+                };
+                this._requiredBlockProviders.set(providerId, loadedProvider);
+                return loadedProvider;
+            } catch (e) {
+                log.warn(`Failed to inspect loaded provider ${providerId}: ${e.message}`);
+            }
+        }
+
+        if (!this.isBuiltinExtension(providerId)) {
+            return null;
+        }
+
+        try {
+            const extensionModule = this.builtinExtensions[providerId]();
+            const extensionInstance = this._instantiateRequiredProvider(extensionModule);
+
+            if (!extensionInstance || typeof extensionInstance.getInfo !== 'function') {
+                log.warn(`Failed to instantiate required provider ${providerId}`);
+                return null;
+            }
+
+            const extensionInfo = extensionInstance.getInfo();
+            const fakeWorkerId = this.nextExtensionWorker++;
+            const serviceName = `required_${fakeWorkerId}_${providerId}`;
+            dispatch.setServiceSync(serviceName, extensionInstance);
+
+            const preparedInfo = this._prepareExtensionInfo(serviceName, extensionInfo);
+            const provider = {
+                serviceName,
+                extensionInfo: preparedInfo
+            };
+
+            this._requiredBlockProviders.set(providerId, provider);
+            return provider;
+        } catch (e) {
+            log.error(`Failed to create required block provider ${providerId}: ${e.message}`);
+            return null;
+        }
+    }
+
+    _instantiateRequiredProvider (extensionModule) {
+        const candidates = [
+            extensionModule,
+            extensionModule && extensionModule.default
+        ];
+
+        for (const candidate of candidates) {
+            const instance = this._toProviderInstance(candidate);
+            if (instance) {
+                return instance;
+            }
+        }
+
+        return null;
+    }
+
+    _toProviderInstance (candidate) {
+        if (!candidate) {
+            return null;
+        }
+
+        if (typeof candidate.getInfo === 'function') {
+            return candidate;
+        }
+
+        if (typeof candidate !== 'function') {
+            return null;
+        }
+
+        try {
+            const constructed = new candidate(this.runtime);
+            if (constructed && typeof constructed.getInfo === 'function') {
+                return constructed;
+            }
+        } catch (e) {
+            // Some modules export a plain function factory instead of a class.
+        }
+
+        try {
+            const created = candidate(this.runtime);
+            if (created && typeof created.getInfo === 'function') {
+                return created;
+            }
+        } catch (e) {
+            return null;
+        }
+
+        return null;
+    }
+
+    _cloneRequiredBlockInfo (providerId, providerBlock, consumerMenus, providerMenus, consumerInfo, providerInfo,
+        providerIsLoaded) {
+        const clonedBlock = Object.assign({}, providerBlock);
+        clonedBlock.arguments = Object.assign({}, providerBlock.arguments || {});
+        clonedBlock.extendedOpcode = `${providerId}_${providerBlock.opcode}`;
+
+        // Borrowed blocks use consumer colors until the provider is loaded.
+        const paletteSource = providerIsLoaded ? providerInfo : consumerInfo;
+        const color1 = paletteSource && paletteSource.color1;
+        const color2 = (paletteSource && paletteSource.color2) || color1;
+        const color3 = (paletteSource && paletteSource.color3) || color2;
+        const color4 = (paletteSource && paletteSource.color4) || color3;
+        clonedBlock.color1 = clonedBlock.color1 || color1;
+        clonedBlock.color2 = clonedBlock.color2 || color2;
+        clonedBlock.color3 = clonedBlock.color3 || color3;
+        clonedBlock.color4 = clonedBlock.color4 || color4;
+
+        for (const argumentName of Object.keys(clonedBlock.arguments)) {
+            const argumentInfo = clonedBlock.arguments[argumentName];
+            if (!argumentInfo || typeof argumentInfo !== 'object') {
+                continue;
+            }
+
+            const clonedArgument = Object.assign({}, argumentInfo);
+            if (typeof clonedArgument.menu === 'string') {
+                const sourceMenuName = clonedArgument.menu;
+                const importedMenuName = `required__${providerId}__${sourceMenuName}`;
+                clonedArgument.menu = importedMenuName;
+
+                if (!Object.prototype.hasOwnProperty.call(consumerMenus, importedMenuName) &&
+                    Object.prototype.hasOwnProperty.call(providerMenus, sourceMenuName)) {
+                    consumerMenus[importedMenuName] = providerMenus[sourceMenuName];
+                }
+            }
+
+            clonedBlock.arguments[argumentName] = clonedArgument;
+        }
+
+        return clonedBlock;
+    }
+
+    getRequiredBlockOwnerForOpcode (opcode) {
+        return this._requiredBlockOpcodeOwners.get(opcode) || null;
     }
 
     /**

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -207,6 +207,7 @@ class ExtensionManager {
         this._loadedExtensions.set(extensionId, serviceName);
         this._requiredBlockProviders.delete(extensionId);
         this._refreshRequiredBlockConsumers(extensionId);
+        this._refreshProvidedBlockTargets(extensionId);
         this.runtime.compilerRegisterExtension(extensionId, extensionInstance);
     }
 
@@ -317,7 +318,9 @@ class ExtensionManager {
         const refresh = serviceName => dispatch.call(serviceName, 'getInfo')
             .then(info => {
                 info = this._prepareExtensionInfo(serviceName, info);
+                info = this._applyProvidesSourceVisibility(info);
                 info = this._injectRequiredBlocks(info);
+                info = this._injectProvidedBlocks(info);
                 dispatch.call('runtime', '_refreshExtensionPrimitives', info);
             })
             .catch(e => {
@@ -360,6 +363,7 @@ class ExtensionManager {
             this._registerExtensionInfo(serviceName, info);
             this._requiredBlockProviders.delete(info.id);
             this._refreshRequiredBlockConsumers(info.id);
+            this._refreshProvidedBlockTargets(info.id);
             this._finishedLoadingExtensionScript();
         });
     }
@@ -419,10 +423,137 @@ class ExtensionManager {
      */
     _registerExtensionInfo (serviceName, extensionInfo) {
         extensionInfo = this._prepareExtensionInfo(serviceName, extensionInfo);
+        extensionInfo = this._applyProvidesSourceVisibility(extensionInfo);
         extensionInfo = this._injectRequiredBlocks(extensionInfo);
+        extensionInfo = this._injectProvidedBlocks(extensionInfo);
         dispatch.call('runtime', '_registerExtensionPrimitives', extensionInfo).catch(e => {
             log.error(`Failed to register primitives for extension on service ${serviceName}:`, e);
         });
+    }
+
+    _applyProvidesSourceVisibility (extensionInfo) {
+        if (!extensionInfo || !extensionInfo.provides || typeof extensionInfo.provides !== 'object') {
+            return extensionInfo;
+        }
+
+        const providedOpcodes = new Set();
+        for (const targetId of Object.keys(extensionInfo.provides)) {
+            const opcodes = extensionInfo.provides[targetId];
+            if (!Array.isArray(opcodes)) {
+                continue;
+            }
+
+            for (const opcode of opcodes) {
+                providedOpcodes.add(String(opcode));
+            }
+        }
+
+        if (providedOpcodes.size === 0 || !Array.isArray(extensionInfo.blocks)) {
+            return extensionInfo;
+        }
+
+        const nextBlocks = extensionInfo.blocks.map(blockInfo => {
+            if (!blockInfo || blockInfo === '---' || typeof blockInfo !== 'object') {
+                return blockInfo;
+            }
+
+            if (!providedOpcodes.has(blockInfo.opcode)) {
+                return blockInfo;
+            }
+
+            return Object.assign({}, blockInfo, {
+                hideFromPalette: true
+            });
+        });
+
+        return Object.assign({}, extensionInfo, {
+            blocks: nextBlocks
+        });
+    }
+
+    _injectProvidedBlocks (extensionInfo) {
+        if (!extensionInfo || !extensionInfo.id) {
+            return extensionInfo;
+        }
+
+        const merged = Object.assign({}, extensionInfo, {
+            blocks: Array.isArray(extensionInfo.blocks) ? extensionInfo.blocks.slice() : [],
+            menus: Object.assign({}, extensionInfo.menus || {})
+        });
+
+        let insertedAny = false;
+
+        for (const [providerId, providerService] of this._loadedExtensions.entries()) {
+            if (providerId === extensionInfo.id) {
+                continue;
+            }
+
+            let providerInfo;
+            try {
+                providerInfo = this._prepareExtensionInfo(providerService, dispatch.callSync(providerService, 'getInfo'));
+            } catch (e) {
+                log.warn(`Failed to inspect provides metadata from ${providerId}: ${e.message}`);
+                continue;
+            }
+
+            if (!providerInfo || !providerInfo.provides || typeof providerInfo.provides !== 'object') {
+                continue;
+            }
+
+            const providedOpcodes = providerInfo.provides[extensionInfo.id];
+            if (!Array.isArray(providedOpcodes) || providedOpcodes.length === 0) {
+                continue;
+            }
+
+            const providerBlocks = providerInfo.blocks || [];
+
+            for (const providedOpcode of providedOpcodes) {
+                const blockOpcode = String(providedOpcode);
+                const providedExtendedOpcode = `${providerId}_${blockOpcode}`;
+
+                const alreadyInTarget = merged.blocks.some(block =>
+                    block &&
+                    typeof block === 'object' &&
+                    block.extendedOpcode === providedExtendedOpcode
+                );
+                if (alreadyInTarget) {
+                    continue;
+                }
+
+                const providerBlock = providerBlocks.find(block =>
+                    block &&
+                    block !== '---' &&
+                    block.opcode === blockOpcode
+                );
+                if (!providerBlock) {
+                    log.warn(`Provided block ${providedExtendedOpcode} was not found in provider ${providerId}`);
+                    continue;
+                }
+
+                const providedBlock = this._cloneRequiredBlockInfo(
+                    providerId,
+                    providerBlock,
+                    merged.menus,
+                    providerInfo.menus || {},
+                    providerInfo,
+                    {
+                        forceShowInPalette: true,
+                        colorSourceInfo: extensionInfo
+                    }
+                );
+
+                if (!insertedAny) {
+                    if (merged.blocks.length > 0 && merged.blocks[merged.blocks.length - 1] !== '---') {
+                        merged.blocks.push('---');
+                    }
+                    insertedAny = true;
+                }
+
+                merged.blocks.push(providedBlock);
+            }
+        }
+
+        return merged;
     }
 
     _injectRequiredBlocks (extensionInfo) {
@@ -533,6 +664,30 @@ class ExtensionManager {
         }
     }
 
+    _refreshProvidedBlockTargets (providerId) {
+        const providerService = this._loadedExtensions.get(providerId);
+        if (!providerService) {
+            return;
+        }
+
+        dispatch.call(providerService, 'getInfo')
+            .then(info => {
+                if (!info || !info.provides || typeof info.provides !== 'object') {
+                    return;
+                }
+
+                for (const targetId of Object.keys(info.provides)) {
+                    if (!this._loadedExtensions.has(targetId)) {
+                        continue;
+                    }
+                    this.refreshBlocks(targetId);
+                }
+            })
+            .catch(e => {
+                log.warn(`Failed to refresh provided block targets for ${providerId}: ${e.message}`);
+            });
+    }
+
     _getRequiredBlockProvider (providerId) {
         if (this._requiredBlockProviders.has(providerId)) {
             return this._requiredBlockProviders.get(providerId);
@@ -636,12 +791,17 @@ class ExtensionManager {
         return null;
     }
 
-    _cloneRequiredBlockInfo (providerId, providerBlock, consumerMenus, providerMenus, providerInfo) {
+    _cloneRequiredBlockInfo (providerId, providerBlock, consumerMenus, providerMenus, providerInfo, options) {
         const clonedBlock = Object.assign({}, providerBlock);
         clonedBlock.arguments = Object.assign({}, providerBlock.arguments || {});
         clonedBlock.extendedOpcode = `${providerId}_${providerBlock.opcode}`;
 
-        const resolvedColors = this._resolveRequiredBlockColors(providerBlock, providerInfo);
+        if (options && options.forceShowInPalette) {
+            clonedBlock.hideFromPalette = false;
+        }
+
+        const colorSourceInfo = (options && options.colorSourceInfo) || providerInfo;
+        const resolvedColors = this._resolveRequiredBlockColors(providerBlock, colorSourceInfo);
         if (resolvedColors) {
             clonedBlock.color1 = resolvedColors.color1;
             clonedBlock.color2 = resolvedColors.color2;

--- a/src/extension-support/extension-manager.js
+++ b/src/extension-support/extension-manager.js
@@ -445,6 +445,9 @@ class ExtensionManager {
 
         for (const providerId of Object.keys(extensionInfo.requires)) {
             const providerIsLoaded = providerId !== extensionInfo.id && this._loadedExtensions.has(providerId);
+            if (providerIsLoaded) {
+                continue;
+            }
 
             const requestedBlocks = extensionInfo.requires[providerId];
             if (!Array.isArray(requestedBlocks) || requestedBlocks.length === 0) {

--- a/src/serialization/sb3.js
+++ b/src/serialization/sb3.js
@@ -297,7 +297,15 @@ E.compressInputTree = function (block, blocks) {
  * @param {!string} opcode The opcode to examine for extension.
  * @return {?string} The extension ID, if it exists and is not a core extension.
  */
-E.getExtensionIdForOpcode = function (opcode) {
+E.getExtensionIdForOpcode = function (opcode, runtime) {
+    if (runtime && runtime.extensionManager &&
+        typeof runtime.extensionManager.getRequiredBlockOwnerForOpcode === 'function') {
+        const requiredOwner = runtime.extensionManager.getRequiredBlockOwnerForOpcode(opcode);
+        if (requiredOwner) {
+            return requiredOwner;
+        }
+    }
+
     // Allowed ID characters are those matching the regular expression [\w-]: A-Z, a-z, 0-9, and hyphen ("-").
     const index = opcode.indexOf('_');
     const forbiddenSymbols = /[^\w-]/g;
@@ -305,6 +313,18 @@ E.getExtensionIdForOpcode = function (opcode) {
     if (E.CORE_EXTENSIONS.indexOf(prefix) === -1) {
         if (prefix !== '') return prefix;
     }
+};
+
+E.shouldTrackExtensionID = function (extensionID, extensions) {
+    if (!extensionID || !extensions) {
+        return false;
+    }
+
+    if (!extensions.declaredExtensionIDs || extensions.declaredExtensionIDs.size === 0) {
+        return true;
+    }
+
+    return extensions.declaredExtensionIDs.has(extensionID);
 };
 
 /**
@@ -348,13 +368,13 @@ E.getExtensionURLsToSave = (extensionIDs, runtime) => {
  * compressed primitives and the list of all extension IDs present
  * in the serialized blocks.
  */
-E.serializeBlocks = function (blocks) {
+E.serializeBlocks = function (blocks, runtime) {
     const obj = Object.create(null);
     const extensionIDs = new Set();
     for (const blockID in blocks) {
         if (!Object.prototype.hasOwnProperty.call(blocks, blockID)) continue;
         obj[blockID] = E.serializeBlock(blocks[blockID], blocks);
-        const extensionID = E.getExtensionIdForOpcode(blocks[blockID].opcode);
+        const extensionID = E.getExtensionIdForOpcode(blocks[blockID].opcode, runtime);
         if (extensionID) {
             extensionIDs.add(extensionID);
         }
@@ -423,7 +443,7 @@ E.deserializeStandaloneBlocks = blocks => {
 E.serializeStandaloneBlocks = (blocks, runtime) => {
     const extensionIDs = new Set();
     for (const block of blocks) {
-        const extensionID = E.getExtensionIdForOpcode(block.opcode);
+        const extensionID = E.getExtensionIdForOpcode(block.opcode, runtime);
         if (extensionID) {
             extensionIDs.add(extensionID);
         }
@@ -584,9 +604,10 @@ E.serializeFrames = function (frames) {
  * for saving and loading this target.
  * @param {object} target The target to be serialized.
  * @param {Set} extensions A set of extensions to add extension IDs to
+ * @param {Runtime} runtime Runtime used for extension ownership inference
  * @return {object} A serialized representation of the given target.
  */
-E.serializeTarget = function (target, extensions) {
+E.serializeTarget = function (target, extensions, runtime) {
     const obj = Object.create(null);
     let targetExtensions = [];
     obj.isStage = target.isStage;
@@ -595,7 +616,7 @@ E.serializeTarget = function (target, extensions) {
     obj.variables = vars.variables;
     obj.lists = vars.lists;
     obj.broadcasts = vars.broadcasts;
-    [obj.blocks, targetExtensions] = E.serializeBlocks(target.blocks);
+    [obj.blocks, targetExtensions] = E.serializeBlocks(target.blocks, runtime);
     obj.comments = E.serializeComments(target.comments);
     obj.frames = E.serializeFrames(target.frames || {});
     obj.tags = Array.isArray(target.tags) ? target.tags.slice() : [];
@@ -674,7 +695,7 @@ E.serializeMonitors = function (monitors, runtime, extensions) {
         // Don't include hidden monitors from extensions
         // https://github.com/LLK/scratch-vm/issues/2331
         .filter(monitorData => {
-            const extensionID = E.getExtensionIdForOpcode(monitorData.opcode);
+            const extensionID = E.getExtensionIdForOpcode(monitorData.opcode, runtime);
             if (!extensionID) {
                 // Native block, always safe
                 return true;
@@ -739,7 +760,7 @@ E.serialize = function (runtime, targetId, {allowOptimization = true} = {}) {
         });
     }
 
-    const serializedTargets = flattenedOriginalTargets.map(t => E.serializeTarget(t, extensions))
+    const serializedTargets = flattenedOriginalTargets.map(t => E.serializeTarget(t, extensions, runtime))
         .map((serialized, index) => {
             // can't serialize extensionStorage until the list of used extensions is fully known
             const target = originalTargetsToSerialize[index];
@@ -1206,7 +1227,7 @@ E.parseScratchObject = function (object, runtime, extensions, zip, assets) {
 
             // If the block is from an extension, record it.
             const extensionID = E.getExtensionIdForOpcode(blockJSON.opcode);
-            if (extensionID) {
+            if (E.shouldTrackExtensionID(extensionID, extensions)) {
                 extensions.extensionIDs.add(extensionID);
             }
         }
@@ -1489,7 +1510,7 @@ E.deserializeMonitor = function (monitorData, runtime, targets, extensions) {
 
         // If the block is from an extension, record it.
         const extensionID = E.getExtensionIdForOpcode(monitorBlock.opcode);
-        if (extensionID) {
+        if (E.shouldTrackExtensionID(extensionID, extensions)) {
             extensions.extensionIDs.add(extensionID);
         }
     }
@@ -1587,8 +1608,16 @@ E.deserialize = async function (json, runtime, zip, isSingleSprite) {
 
     const extensions = {
         extensionIDs: new Set(),
-        extensionURLs: new Map()
+        extensionURLs: new Map(),
+        declaredExtensionIDs: null
     };
+
+    if (Array.isArray(json.extensions)) {
+        extensions.declaredExtensionIDs = new Set(json.extensions);
+        for (const extensionID of extensions.declaredExtensionIDs) {
+            extensions.extensionIDs.add(extensionID);
+        }
+    }
 
     // Store the origin field (e.g. project originated at CSFirst) so that we can save it again.
     if (json.meta && json.meta.origin) {


### PR DESCRIPTION
Extensions can provide blocks to other extensions.

If an extension is designed to work well with another extension (ie, using vectors as inputs), they can "require" only the blocks they need, without loading the entire extension into the flyout.

This prevents having to duplicate blocks between extensions in order to provide minimum-compatible integrations; in other words, you can install an extension and have everything you need.